### PR TITLE
fix: evaluated module should be freed

### DIFF
--- a/src/jac/features/moduleLoaderFeature.h
+++ b/src/jac/features/moduleLoaderFeature.h
@@ -36,6 +36,8 @@ private:
         meta.set("url", filename);
         meta.set("main", false);
 
+        JS_FreeValue(ctx, val);
+
         return mdl;
     }
 


### PR DESCRIPTION
Reference: https://github.com/bellard/quickjs/blob/36911f0d3ab1a4c190a4d5cbe7c2db225a455389/quickjs-libc.c#L605C9-L605C21

Didn't notice any impact, just found it while debugging.